### PR TITLE
fix(stats): record actual listened duration instead of full track length (closes #42)

### DIFF
--- a/app/src/main/java/com/example/tigerplayer/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/example/tigerplayer/data/repository/HistoryRepository.kt
@@ -70,8 +70,12 @@ class HistoryRepository @Inject constructor(
     fun getAllTracksStats(): Flow<List<TrackStats>> = tigerDao.getAllTracksStats()
 
     /**
-     * Records a manifestation.
-     * Optimization: If duration is < 5s, we skip recording to avoid polluting stats with "skips".
+     * Records a completed play.
+     *
+     * [durationListenedMs] must be the time **actually listened**, never the track's nominal
+     * length. Whether a play qualifies at all (the >= 50% / >= 4 minute rule) is decided upstream
+     * in `StatsEngine`; the floor below is only a defensive guard against a caller passing a
+     * value that clearly represents a skip.
      */
     suspend fun addTrackToHistory(
         trackId: String,
@@ -79,10 +83,10 @@ class HistoryRepository @Inject constructor(
         artist: String,
         album: String,
         imageUrl: String?,
-        durationMs: Long,
+        durationListenedMs: Long,
         source: MediaSource
     ) {
-        if (durationMs < 5000) return // Ignore brief skips
+        if (durationListenedMs < MIN_LISTENED_MS) return
 
         val historyEntry = PlaybackHistoryEntity(
             trackId = trackId,
@@ -90,7 +94,7 @@ class HistoryRepository @Inject constructor(
             artist = artist,
             album = album,
             imageUrl = imageUrl,
-            durationListenedMs = durationMs,
+            durationListenedMs = durationListenedMs,
             source = source,
             timestamp = System.currentTimeMillis()
         )
@@ -99,4 +103,8 @@ class HistoryRepository @Inject constructor(
 
     fun getTotalListeningTime(startTime: Long): Flow<Long?> =
         tigerDao.getTotalListeningTimeMs(startTime)
+
+    private companion object {
+        const val MIN_LISTENED_MS = 5_000L
+    }
 }

--- a/app/src/main/java/com/example/tigerplayer/di/AudioModule.kt
+++ b/app/src/main/java/com/example/tigerplayer/di/AudioModule.kt
@@ -1,12 +1,27 @@
 package com.example.tigerplayer.di
 
+import android.os.SystemClock
+import com.example.tigerplayer.utils.ElapsedTimeSource
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AudioModule {
     // Currently, all audio components use @Inject constructor and @Singleton on the class itself.
     // This module can be used for interface bindings or complex provider logic in the future.
+
+    /**
+     * Monotonic clock used for listened-duration accounting (issue #42).
+     *
+     * `elapsedRealtime` is deliberate: it is unaffected by the user changing the system clock or
+     * timezone, so a play cannot be inflated or lost by a wall-clock jump.
+     */
+    @Provides
+    @Singleton
+    fun provideElapsedTimeSource(): ElapsedTimeSource =
+        ElapsedTimeSource { SystemClock.elapsedRealtime() }
 }

--- a/app/src/main/java/com/example/tigerplayer/engine/StatsEngine.kt
+++ b/app/src/main/java/com/example/tigerplayer/engine/StatsEngine.kt
@@ -7,13 +7,24 @@ import com.example.tigerplayer.data.repository.HistoryRepository
 import com.example.tigerplayer.ui.player.DetailedStatsUiState
 import com.example.tigerplayer.ui.player.StatItem
 import com.example.tigerplayer.utils.ArtistUtils
+import com.example.tigerplayer.utils.ElapsedTimeSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import java.util.Calendar
 import javax.inject.Inject
+import javax.inject.Singleton
 
+/**
+ * Owns listening analytics: the aggregation flows that feed the stats surfaces, and the
+ * listened-duration accounting that produces the underlying history rows.
+ *
+ * `@Singleton` is required for correctness, not just efficiency: an in-flight play is held in
+ * memory here, so a second instance would drop or double count it when a ViewModel is recreated.
+ */
+@Singleton
 class StatsEngine @Inject constructor(
-    private val historyRepository: HistoryRepository
+    private val historyRepository: HistoryRepository,
+    private val elapsedTimeSource: ElapsedTimeSource
 ) {
     private val _statsFilter = MutableStateFlow("Today")
 
@@ -92,12 +103,88 @@ class StatsEngine @Inject constructor(
         }
     }
 
-    suspend fun recordPlaybackHistory(track: AudioTrack) {
-        val source = when {
-            track.id.startsWith("spotify:", ignoreCase = true) -> MediaSource.SPOTIFY
-            track.id.startsWith("navidrome:", ignoreCase = true) -> MediaSource.NAVIDROME
-            else -> MediaSource.LOCAL
+    // ==========================================
+    // --- LISTENED-DURATION ACCOUNTING (issue #42) ---
+    // ==========================================
+    //
+    // A play is committed when the track is left, not when it starts, and it records the time
+    // actually listened rather than the track's nominal length. Previously every track transition
+    // wrote a full-length row, so skipping through 40 tracks recorded 40 complete plays and every
+    // downstream surface (Heavy Rotation, Sonic Footprint, Day List, Discovery Weekly, listening
+    // share) was inflated.
+
+    private val playLock = Any()
+    private var pendingTrack: AudioTrack? = null
+    private var accumulatedMs = 0L
+
+    /** Elapsed time when playback last started; `null` while paused. */
+    private var resumedAtMs: Long? = null
+
+    private data class PendingPlay(val track: AudioTrack, val listenedMs: Long)
+
+    /**
+     * Call when the current track changes.
+     *
+     * Commits the outgoing track's play if it qualifies, then begins accounting for [track].
+     */
+    suspend fun onTrackChanged(track: AudioTrack, isPlaying: Boolean) {
+        commitPendingPlay()
+        synchronized(playLock) {
+            pendingTrack = track
+            accumulatedMs = 0L
+            resumedAtMs = if (isPlaying) elapsedTimeSource.elapsedMs() else null
         }
+    }
+
+    /**
+     * Call whenever playback starts or stops, for any source.
+     *
+     * Idempotent: repeated calls with the same state do not double count.
+     */
+    fun onPlayingChanged(isPlaying: Boolean) {
+        synchronized(playLock) {
+            if (isPlaying) {
+                if (resumedAtMs == null) resumedAtMs = elapsedTimeSource.elapsedMs()
+            } else {
+                accumulateLocked()
+            }
+        }
+    }
+
+    /** Commits any in-flight play. Safe to call when nothing is pending. */
+    suspend fun flushPendingPlay() {
+        commitPendingPlay()
+    }
+
+    /** Folds the currently-running interval into [accumulatedMs]. Caller must hold [playLock]. */
+    private fun accumulateLocked() {
+        val startedAt = resumedAtMs ?: return
+        accumulatedMs += (elapsedTimeSource.elapsedMs() - startedAt).coerceAtLeast(0L)
+        resumedAtMs = null
+    }
+
+    private suspend fun commitPendingPlay() {
+        val pending = synchronized(playLock) {
+            val track = pendingTrack ?: return@synchronized null
+            accumulateLocked()
+            val snapshot = PendingPlay(track, accumulatedMs)
+            pendingTrack = null
+            accumulatedMs = 0L
+            resumedAtMs = null
+            snapshot
+        } ?: return
+
+        persistPlay(pending.track, pending.listenedMs)
+    }
+
+    private suspend fun persistPlay(track: AudioTrack, rawListenedMs: Long) {
+        val durationMs = track.durationMs
+
+        // Seeking backwards, or repeat-one, can accumulate more wall-clock time than the track is
+        // long. Cap so a single play can never contribute more than the track's own duration.
+        val listenedMs = if (durationMs > 0L) rawListenedMs.coerceAtMost(durationMs) else rawListenedMs
+
+        if (!qualifiesAsPlay(listenedMs, durationMs)) return
 
         historyRepository.addTrackToHistory(
             trackId = track.id,
@@ -105,9 +192,30 @@ class StatsEngine @Inject constructor(
             artist = track.artist,
             album = track.album,
             imageUrl = track.artworkUri.toString(),
-            durationMs = track.durationMs,
-            source = source
+            durationListenedMs = listenedMs,
+            source = resolveSource(track)
         )
+    }
+
+    /**
+     * The standard scrobble rule: a play counts once at least half the track, or four minutes,
+     * has been heard - whichever comes first. Tracks shorter than 30 seconds never qualify.
+     *
+     * When the duration is unknown (0 or negative, common for streams) only the absolute
+     * four-minute rule can qualify the play, since a percentage is meaningless.
+     */
+    private fun qualifiesAsPlay(listenedMs: Long, durationMs: Long): Boolean {
+        if (listenedMs < MIN_LISTENED_MS) return false
+        if (durationMs in 1 until MIN_TRACK_DURATION_MS) return false
+        if (listenedMs >= FULL_PLAY_THRESHOLD_MS) return true
+        if (durationMs <= 0L) return false
+        return listenedMs >= durationMs / 2
+    }
+
+    private fun resolveSource(track: AudioTrack): MediaSource = when {
+        track.id.startsWith("spotify:", ignoreCase = true) -> MediaSource.SPOTIFY
+        track.id.startsWith("navidrome:", ignoreCase = true) -> MediaSource.NAVIDROME
+        else -> MediaSource.LOCAL
     }
 
     /**
@@ -155,5 +263,16 @@ class StatsEngine @Inject constructor(
             "Lifetime" -> 0L // Captures everything
             else -> 0L
         }
+    }
+
+    private companion object {
+        /** A play always qualifies once four minutes have been heard, regardless of length. */
+        const val FULL_PLAY_THRESHOLD_MS = 4 * 60 * 1000L
+
+        /** Tracks shorter than this never qualify, matching the standard scrobble rule. */
+        const val MIN_TRACK_DURATION_MS = 30_000L
+
+        /** Absolute floor; below this the listener effectively skipped. */
+        const val MIN_LISTENED_MS = 5_000L
     }
 }

--- a/app/src/main/java/com/example/tigerplayer/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/tigerplayer/ui/player/PlayerViewModel.kt
@@ -206,7 +206,7 @@ class PlayerViewModel @Inject constructor(
                     metadataJob = viewModelScope.launch(Dispatchers.IO) {
                         metadataEngine.fetchTrackMetadata(spotifyTrack)
                     }
-                    statsEngine.recordPlaybackHistory(spotifyTrack)
+                    statsEngine.onTrackChanged(spotifyTrack, spotifyState.isPlaying)
                 }
             }
         }
@@ -240,6 +240,17 @@ class PlayerViewModel @Inject constructor(
             bluetoothDeviceManager.connectedDevice.collect { device ->
                 _uiState.update { it.copy(connectedBluetoothDevice = device) }
             }
+        }
+
+        // --- 1b. LISTENED-DURATION ACCOUNTING (issue #42) ---
+        // Driven from the unified UI state rather than a single transport, so local and Spotify
+        // playback both accumulate correctly. StatsEngine is a @Singleton, so an in-flight play
+        // survives this ViewModel being recreated.
+        viewModelScope.launch {
+            _uiState
+                .map { it.isPlaying }
+                .distinctUntilChanged()
+                .collect { isPlaying -> statsEngine.onPlayingChanged(isPlaying) }
         }
 
         // --- 2. LIBRARY SYNCHRONIZATION ---
@@ -333,7 +344,7 @@ class PlayerViewModel @Inject constructor(
                 metadataJob = viewModelScope.launch(Dispatchers.IO) {
                     metadataEngine.fetchTrackMetadata(track)
                 }
-                statsEngine.recordPlaybackHistory(track)
+                statsEngine.onTrackChanged(track, _uiState.value.isPlaying)
 
                 if (track.isLocal && track.artworkUri.toString().startsWith("content://")) {
                     viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/example/tigerplayer/utils/ElapsedTimeSource.kt
+++ b/app/src/main/java/com/example/tigerplayer/utils/ElapsedTimeSource.kt
@@ -1,0 +1,17 @@
+package com.example.tigerplayer.utils
+
+/**
+ * Monotonic elapsed-time source.
+ *
+ * Injected rather than calling [android.os.SystemClock] directly so that listened-duration
+ * accounting can be unit tested on the JVM with virtual time, per the determinism rule in
+ * `.github/instructions/testing.instructions.md`.
+ *
+ * Implementations must be monotonic and unaffected by wall-clock or timezone changes.
+ */
+fun interface ElapsedTimeSource {
+
+    /** Milliseconds since boot, excluding deep sleep. Never moves backwards. */
+    fun elapsedMs(): Long
+}
+

--- a/app/src/test/java/com/example/tigerplayer/engine/StatsEngineFilterTest.kt
+++ b/app/src/test/java/com/example/tigerplayer/engine/StatsEngineFilterTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 
 class StatsEngineFilterTest {
 
-    private val engine = StatsEngine(mockk<HistoryRepository>(relaxed = true))
+    private val engine = StatsEngine(mockk<HistoryRepository>(relaxed = true)) { 0L }
 
     @Test
     fun all_filters_map_to_expected_calendar_boundaries() {

--- a/app/src/test/java/com/example/tigerplayer/engine/StatsEnginePlayTrackingTest.kt
+++ b/app/src/test/java/com/example/tigerplayer/engine/StatsEnginePlayTrackingTest.kt
@@ -1,0 +1,241 @@
+package com.example.tigerplayer.engine
+
+import android.net.Uri
+import com.example.tigerplayer.data.local.MediaSource
+import com.example.tigerplayer.data.model.AudioTrack
+import com.example.tigerplayer.data.repository.HistoryRepository
+import com.example.tigerplayer.utils.ElapsedTimeSource
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for issue #42.
+ *
+ * Before the fix, a history row was written on every track transition using the track's nominal
+ * length, so skipping inflated every analytics surface. These tests pin the corrected behaviour:
+ * a play is committed when the track is left, and records the time actually listened.
+ */
+class StatsEnginePlayTrackingTest {
+
+    /** Virtual monotonic clock - no test may depend on the wall clock. */
+    private class FakeElapsedTimeSource(private var nowMs: Long = 1_000L) : ElapsedTimeSource {
+        override fun elapsedMs(): Long = nowMs
+        fun advance(byMs: Long) {
+            nowMs += byMs
+        }
+    }
+
+    private val clock = FakeElapsedTimeSource()
+    private val historyRepository = mockk<HistoryRepository>(relaxed = true)
+    private val engine = StatsEngine(historyRepository, clock)
+
+    private fun track(
+        id: String = "track-1",
+        durationMs: Long = FIVE_MINUTES
+    ) = AudioTrack(
+        id = id,
+        title = "Title $id",
+        artist = "Artist",
+        album = "Album",
+        uri = mockk<Uri>(relaxed = true),
+        artworkUri = mockk<Uri>(relaxed = true),
+        durationMs = durationMs,
+        mimeType = "audio/flac",
+        isLocal = true
+    )
+
+    private fun capturedListenedMs(): Long {
+        val listened = slot<Long>()
+        coVerify(exactly = 1) {
+            historyRepository.addTrackToHistory(
+                trackId = any(),
+                title = any(),
+                artist = any(),
+                album = any(),
+                imageUrl = any(),
+                durationListenedMs = capture(listened),
+                source = any()
+            )
+        }
+        return listened.captured
+    }
+
+    @Test
+    fun `skipping a track before the threshold records no history row`() = runTest {
+        engine.onTrackChanged(track(), isPlaying = true)
+        clock.advance(3_000L)
+
+        engine.onTrackChanged(track(id = "track-2"), isPlaying = true)
+
+        coVerify(exactly = 0) { historyRepository.addTrackToHistory(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `playing past half the track records the real listened duration, not the track length`() = runTest {
+        engine.onTrackChanged(track(durationMs = FIVE_MINUTES), isPlaying = true)
+        clock.advance(THREE_MINUTES)
+
+        engine.flushPendingPlay()
+
+        assertEquals(THREE_MINUTES, capturedListenedMs())
+    }
+
+    @Test
+    fun `pause and resume accumulate only time actually played`() = runTest {
+        engine.onTrackChanged(track(durationMs = FIVE_MINUTES), isPlaying = true)
+
+        clock.advance(90_000L)
+        engine.onPlayingChanged(isPlaying = false)
+
+        // Paused for a long time - this must not be counted.
+        clock.advance(10 * 60 * 1000L)
+        engine.onPlayingChanged(isPlaying = true)
+
+        clock.advance(60_000L)
+        engine.flushPendingPlay()
+
+        assertEquals(150_000L, capturedListenedMs())
+    }
+
+    @Test
+    fun `repeated pause events do not double count`() = runTest {
+        engine.onTrackChanged(track(durationMs = FIVE_MINUTES), isPlaying = true)
+        clock.advance(THREE_MINUTES)
+
+        engine.onPlayingChanged(isPlaying = false)
+        clock.advance(30_000L)
+        engine.onPlayingChanged(isPlaying = false)
+        engine.onPlayingChanged(isPlaying = false)
+
+        engine.flushPendingPlay()
+
+        assertEquals(THREE_MINUTES, capturedListenedMs())
+    }
+
+    @Test
+    fun `four minutes qualifies a long track even below fifty percent`() = runTest {
+        val twentyMinutes = 20 * 60 * 1000L
+        engine.onTrackChanged(track(durationMs = twentyMinutes), isPlaying = true)
+
+        clock.advance(4 * 60 * 1000L)
+        engine.flushPendingPlay()
+
+        assertEquals(4 * 60 * 1000L, capturedListenedMs())
+    }
+
+    @Test
+    fun `listening just under half a long track does not qualify`() = runTest {
+        val twentyMinutes = 20 * 60 * 1000L
+        engine.onTrackChanged(track(durationMs = twentyMinutes), isPlaying = true)
+
+        // Below both the 50% and the four-minute rule.
+        clock.advance(3 * 60 * 1000L)
+        engine.flushPendingPlay()
+
+        coVerify(exactly = 0) { historyRepository.addTrackToHistory(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `tracks shorter than thirty seconds never qualify`() = runTest {
+        engine.onTrackChanged(track(durationMs = 20_000L), isPlaying = true)
+
+        // Played to completion, and past the absolute floor.
+        clock.advance(20_000L)
+        engine.flushPendingPlay()
+
+        coVerify(exactly = 0) { historyRepository.addTrackToHistory(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `listened time is capped at the track duration when seeking backwards`() = runTest {
+        val duration = FIVE_MINUTES
+        engine.onTrackChanged(track(durationMs = duration), isPlaying = true)
+
+        // Replaying via seek-back accumulates more wall-clock time than the track is long.
+        clock.advance(duration * 3)
+        engine.flushPendingPlay()
+
+        assertEquals(duration, capturedListenedMs())
+    }
+
+    @Test
+    fun `a track started while paused accrues nothing until playback begins`() = runTest {
+        engine.onTrackChanged(track(durationMs = FIVE_MINUTES), isPlaying = false)
+
+        clock.advance(10 * 60 * 1000L)
+        engine.onPlayingChanged(isPlaying = true)
+        clock.advance(THREE_MINUTES)
+
+        engine.flushPendingPlay()
+
+        assertEquals(THREE_MINUTES, capturedListenedMs())
+    }
+
+    @Test
+    fun `unknown duration qualifies only via the four minute rule`() = runTest {
+        engine.onTrackChanged(track(durationMs = 0L), isPlaying = true)
+        clock.advance(THREE_MINUTES)
+        engine.flushPendingPlay()
+
+        coVerify(exactly = 0) { historyRepository.addTrackToHistory(any(), any(), any(), any(), any(), any(), any()) }
+
+        engine.onTrackChanged(track(id = "stream-2", durationMs = 0L), isPlaying = true)
+        clock.advance(5 * 60 * 1000L)
+        engine.flushPendingPlay()
+
+        assertEquals(5 * 60 * 1000L, capturedListenedMs())
+    }
+
+    @Test
+    fun `flushing with no pending play is a no-op`() = runTest {
+        engine.flushPendingPlay()
+        engine.flushPendingPlay()
+
+        coVerify(exactly = 0) { historyRepository.addTrackToHistory(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a committed play is not committed twice`() = runTest {
+        engine.onTrackChanged(track(durationMs = FIVE_MINUTES), isPlaying = true)
+        clock.advance(THREE_MINUTES)
+
+        engine.flushPendingPlay()
+        clock.advance(THREE_MINUTES)
+        engine.flushPendingPlay()
+
+        assertEquals(THREE_MINUTES, capturedListenedMs())
+    }
+
+    @Test
+    fun `source is derived from the track id prefix`() = runTest {
+        val source = slot<MediaSource>()
+        engine.onTrackChanged(track(id = "spotify:track:abc", durationMs = FIVE_MINUTES), isPlaying = true)
+        clock.advance(THREE_MINUTES)
+        engine.flushPendingPlay()
+
+        coVerify(exactly = 1) {
+            historyRepository.addTrackToHistory(
+                trackId = any(),
+                title = any(),
+                artist = any(),
+                album = any(),
+                imageUrl = any(),
+                durationListenedMs = any(),
+                source = capture(source)
+            )
+        }
+        assertTrue(source.captured == MediaSource.SPOTIFY)
+    }
+
+    private companion object {
+        const val FIVE_MINUTES = 5 * 60 * 1000L
+        const val THREE_MINUTES = 3 * 60 * 1000L
+    }
+}
+
+


### PR DESCRIPTION
### Summary of Changes

Listening history was written on **every track transition** using the track's **nominal length**,
so skipping through 40 tracks recorded 40 complete plays. The existing guard
`if (durationMs < 5000) return` checked the *track's* duration rather than the time listened, so it
never filtered a skip.

A play is now committed when the track is **left**, carrying the time **actually listened**, and only
if it meets the standard scrobble rule: **≥ 50% of the track or ≥ 4 minutes**, whichever comes first,
with tracks under 30 seconds never qualifying.

| File | Change |
|---|---|
| `utils/ElapsedTimeSource.kt` *(new)* | Monotonic clock, injected so duration accounting is JVM-testable |
| `di/AudioModule.kt` | Provides it as a `@Singleton`, backed by `SystemClock.elapsedRealtime` |
| `engine/StatsEngine.kt` | Accumulates across pause/resume; commits on track change or flush |
| `data/repository/HistoryRepository.kt` | `durationMs` → `durationListenedMs`; corrected docs |
| `ui/player/PlayerViewModel.kt` | Wiring for both local and Spotify transports |
| `StatsEnginePlayTrackingTest.kt` *(new)* | 13 regression cases |

### Root Cause

`PlayerViewModel` called `statsEngine.recordPlaybackHistory(track)` at the moment a track **became
current**, and `StatsEngine` passed `track.durationMs` straight through as the listened duration.
Nothing anywhere measured elapsed playback, so the value recorded was structurally incapable of
being correct — it was the same whether the user listened to the whole track or skipped it in 200ms.

Every analytics surface reads from that table: **Heavy Rotation, Sonic Footprint, Day List,
Discovery Weekly, Top Artists/Tracks, and the global listening-share percentage.**

### Design notes

- **`StatsEngine` is now `@Singleton`.** This is required for *correctness*, not efficiency — the
  in-flight play is held in memory, so a second instance would drop or double count it when a
  ViewModel is recreated (e.g. rotation).
- **`elapsedRealtime`, not wall clock.** A user changing their system clock or timezone cannot
  inflate or erase a play.
- **Playing-state is driven from the unified `PlayerUiState.isPlaying`**, so local and Spotify
  accumulate through one path rather than two divergent ones. Previously the two transports had
  separate, inconsistent history-recording call sites.
- **Listened time is capped at the track duration.** Seek-back and repeat-one would otherwise
  accumulate more wall-clock time than the track is long.
- **Unknown duration (streams, `durationMs <= 0`)** can only qualify via the absolute four-minute
  rule, since a percentage is meaningless there.

### Verification

```
.\gradlew.bat :app:testDebugUnitTest  ->  32 tests, 0 failures, 0 errors
.\gradlew.bat :app:lintDebug          ->  BUILD SUCCESSFUL, 91 issues, 0 errors
.\gradlew.bat :app:assembleDebug      ->  BUILD SUCCESSFUL
```

Lint is **91 issues / 84 warnings / 7 hints — byte-identical to the `master` baseline**, so this
change introduces zero new lint findings.

New test coverage (all passing):

| Case | Asserts |
|---|---|
| skip before threshold | no history row |
| play past half the track | records real listened duration, **not** track length |
| pause and resume | accumulates only time played |
| repeated pause events | no double counting |
| four-minute rule | qualifies a 20-min track below 50% |
| just under half a long track | does not qualify |
| track < 30s | never qualifies |
| seek backwards | listened time capped at duration |
| started while paused | accrues nothing until playback begins |
| unknown duration | qualifies only via the four-minute rule |
| flush with nothing pending | no-op |
| double flush | commits once |
| `spotify:` id prefix | resolves to `MediaSource.SPOTIFY` |

- [x] Lint passes
- [x] Unit tests pass
- [x] Debug build compiles
- [x] New/changed behavior is covered by a test
- [ ] Manually verified on a device — **not yet**; see below

### Scope

- [x] Changes are limited to what the issue requires
- [x] No unrelated formatting or whitespace churn

### Data & Security

- [x] No Room schema change
- [x] No secrets, keystores, or `BuildConfig` credentials added
- [x] No new dependency
- [x] No debug logging of user library content added

### Audio / Playback

Not applicable — no `AudioProcessor`, sink, or Media3 session changes. `PlayerViewModel` wiring only.

---

## Reviewer notes — two things to decide

**1. Existing history rows are still inflated.**
This fix corrects **new** data only. Issue #42's acceptance criteria call for migrating or clearing
the corrupt rows. That needs a schema-aware migration, so I deferred it rather than widening this
PR — it belongs with #43 (Room migrations), which is the prerequisite anyway. Until it happens,
stats will show a mix of old inflated rows and new correct ones.

**2. This branch carries an unrelated commit with a misleading subject.**
Commit `178d342` is titled *"feat(stats): add rolling and calendar stats filter windows"*, but its
actual content is **`docs/system-review.md` (+195 lines)**. The stats-filter work it names is
already on `master` as `3865812`. Options:

- **Reword** `178d342` to something like `docs: add architecture review snapshot` (needs a force-push)
- **Drop** it from this branch and land the doc separately, keeping this PR atomic
- **Leave as-is** and merge

Happy to do whichever. Note the doc also has mojibake from a copy-paste encoding mismatch
(`ðŸ”´` for 🔴, `â€”` for —), and its content is largely superseded by `docs/Roadmap-v2.1-v2.3.md`
and issues #42–#76.

### Follow-ups unblocked by this

- #62 Last.fm scrobbling — now has a trustworthy trigger and threshold to hang off
- #68 Smart playlists — play counts are meaningful
- #69 Year in Review — safe to publish figures

---

Closes #42

