### PR TITLE
fix(navidrome): sign stream and art URLs at request time (closes #44)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,13 @@ configure<ApplicationExtension> {
         buildConfig = true
     }
 
+    testOptions {
+        unitTests {
+            // Required by Robolectric so JVM tests can resolve Android resources.
+            isIncludeAndroidResources = true
+        }
+    }
+
     packaging {
         jniLibs {
             useLegacyPackaging = true
@@ -167,6 +174,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    // Robolectric provides a real android.net.Uri on the JVM, so URI/signing logic can be unit
+    // tested without a device. Test-only; ships nothing.
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/tigerplayer/TigerPlayerApplication.kt
+++ b/app/src/main/java/com/example/tigerplayer/TigerPlayerApplication.kt
@@ -3,6 +3,10 @@ package com.example.tigerplayer
 import android.app.Application
 import android.os.StrictMode
 import android.util.Log
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import com.example.tigerplayer.data.remote.NavidromeArtInterceptor
+import com.example.tigerplayer.data.remote.NavidromeUrlSigner
 import com.example.tigerplayer.data.repository.StatsEpoch
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -12,10 +16,13 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 @HiltAndroidApp
-class TigerPlayerApplication : Application() {
+class TigerPlayerApplication : Application(), ImageLoaderFactory {
 
 	@Inject
 	lateinit var statsEpoch: StatsEpoch
+
+	@Inject
+	lateinit var navidromeUrlSigner: NavidromeUrlSigner
 
 	private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -33,6 +40,19 @@ class TigerPlayerApplication : Application() {
 			installStrictMode()
 		}
 	}
+
+	/**
+	 * Coil loader that resolves opaque `navidrome://art/<id>` URIs into freshly signed URLs at
+	 * request time (issue #44).
+	 *
+	 * Artwork URIs are persisted alongside tracks, so like stream URIs they must not carry a
+	 * rotating token. Signing in an interceptor keeps every `AsyncImage` call site unchanged.
+	 */
+	override fun newImageLoader(): ImageLoader = ImageLoader.Builder(this)
+		.components {
+			add(NavidromeArtInterceptor(navidromeUrlSigner))
+		}
+		.build()
 
 	private fun installStrictMode() {
 		StrictMode.setThreadPolicy(

--- a/app/src/main/java/com/example/tigerplayer/data/local/NavidromePrefs.kt
+++ b/app/src/main/java/com/example/tigerplayer/data/local/NavidromePrefs.kt
@@ -36,6 +36,15 @@ class NavidromePrefs @Inject constructor(
     val username: Flow<String?> = _username
     val password: Flow<String?> = _password
 
+    // Synchronous snapshots for callers that cannot suspend - notably the Media3 data-source
+    // resolver and the Coil interceptor, which sign requests on a loading thread (issue #44).
+    // Backed by the same in-memory StateFlow, so no disk or crypto work happens here.
+    fun serverUrlSnapshot(): String? = _serverUrl.value
+
+    fun usernameSnapshot(): String? = _username.value
+
+    fun passwordSnapshot(): String? = _password.value
+
     /**
      * Stores the credentials. This is called when you hit "Initiate Sync".
      */

--- a/app/src/main/java/com/example/tigerplayer/data/remote/NavidromeArtInterceptor.kt
+++ b/app/src/main/java/com/example/tigerplayer/data/remote/NavidromeArtInterceptor.kt
@@ -1,0 +1,49 @@
+package com.example.tigerplayer.data.remote
+
+import android.net.Uri
+import androidx.core.net.toUri
+import coil.intercept.Interceptor
+import coil.request.ImageResult
+
+/**
+ * Signs opaque `navidrome://art/<id>` requests just before Coil fetches them (issue #44).
+ *
+ * Artwork URIs are persisted alongside tracks, so they must not carry a rotating Subsonic token.
+ * Resolving here keeps every `AsyncImage` call site unchanged, and means a cached or restored
+ * artwork URI still loads after the original token has expired.
+ */
+class NavidromeArtInterceptor(
+    private val signer: NavidromeUrlSigner
+) : Interceptor {
+
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val request = chain.request
+        val uri = when (val data = request.data) {
+            is Uri -> data
+            is String -> runCatching { data.toUri() }.getOrNull()
+            else -> null
+        }
+
+        if (uri == null || !NavidromeUri.isNavidrome(uri)) {
+            return chain.proceed(request)
+        }
+
+        // Without credentials there is nothing sensible to fetch; let Coil fail normally so the
+        // caller's error placeholder shows. Never log the URI - a signed one carries a token.
+        val signed = signer.sign(uri) ?: return chain.proceed(request)
+
+        // Cache keys must be pinned to the *opaque* URI. Each sign() call mints a fresh salt, so
+        // the signed URL differs every time; letting Coil derive keys from it would make every
+        // lookup a miss and re-download artwork on every scroll.
+        val stableKey = uri.toString()
+
+        return chain.proceed(
+            request.newBuilder()
+                .data(signed.toString())
+                .memoryCacheKey(stableKey)
+                .diskCacheKey(stableKey)
+                .build()
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/tigerplayer/data/remote/NavidromeUri.kt
+++ b/app/src/main/java/com/example/tigerplayer/data/remote/NavidromeUri.kt
@@ -1,0 +1,112 @@
+package com.example.tigerplayer.data.remote
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.example.tigerplayer.data.local.NavidromePrefs
+import com.example.tigerplayer.utils.NavidromeSecurity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Opaque, credential-free identifiers for Navidrome resources (issue #44).
+ *
+ * Subsonic authenticates with a salted MD5 token that rotates. Persisting a signed URL - into Room,
+ * into the queue snapshot, or into a `MediaItem` - produces a URL that is valid when written and
+ * silently dead when replayed. These URIs carry only the resource id, so they are safe to persist
+ * indefinitely; the signature is applied at request time by [NavidromeUrlSigner].
+ *
+ * Format: `navidrome://stream/<id>` and `navidrome://art/<id>`.
+ */
+object NavidromeUri {
+
+    const val SCHEME = "navidrome"
+    const val HOST_STREAM = "stream"
+    const val HOST_ART = "art"
+
+    /**
+     * Prefix applied to [com.example.tigerplayer.data.model.AudioTrack.id] for remote tracks.
+     *
+     * Deliberately `navidrome_`, matching what `NavidromeMapper` already emitted before issue #44.
+     * Track ids are foreign keys in `playlist_track_cross_ref`, `playback_history`, `lyrics_cache`
+     * and `waveform_cache`, and are embedded in the persisted queue snapshot - changing the
+     * separator would orphan every one of those rows with no migration to repair them.
+     */
+    const val TRACK_ID_PREFIX = "navidrome_"
+
+    fun stream(id: String): Uri = build(HOST_STREAM, id)
+
+    fun art(id: String): Uri = build(HOST_ART, id)
+
+    fun isNavidrome(uri: Uri): Boolean = uri.scheme == SCHEME
+
+    /** The resource id, or `null` if [uri] is not one of ours. */
+    fun resourceId(uri: Uri): String? {
+        if (!isNavidrome(uri)) return null
+        return uri.pathSegments.firstOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    fun isStream(uri: Uri): Boolean = isNavidrome(uri) && uri.host == HOST_STREAM
+
+    fun isArt(uri: Uri): Boolean = isNavidrome(uri) && uri.host == HOST_ART
+
+    private fun build(host: String, id: String): Uri = Uri.Builder()
+        .scheme(SCHEME)
+        .authority(host)
+        .appendPath(id)
+        .build()
+}
+
+/**
+ * Turns an opaque [NavidromeUri] into a freshly signed HTTPS/HTTP URL.
+ *
+ * A new salt and token are generated per call, so a URL is never reused beyond the request that
+ * created it. Returns `null` when credentials are absent, which callers must treat as "not
+ * playable" rather than falling back to an unsigned request.
+ */
+@Singleton
+class NavidromeUrlSigner @Inject constructor(
+    private val navidromePrefs: NavidromePrefs
+) {
+
+    /**
+     * @return a signed absolute URL, or `null` if [uri] is not a Navidrome URI or the user is not
+     *   currently linked to a server.
+     */
+    fun sign(uri: Uri): Uri? {
+        val id = NavidromeUri.resourceId(uri) ?: return null
+        val baseUrl = navidromePrefs.serverUrlSnapshot()?.takeIf { it.isNotBlank() } ?: return null
+        val user = navidromePrefs.usernameSnapshot()?.takeIf { it.isNotBlank() } ?: return null
+        val pass = navidromePrefs.passwordSnapshot()?.takeIf { it.isNotBlank() } ?: return null
+
+        val endpoint = when {
+            NavidromeUri.isArt(uri) -> "getCoverArt.view"
+            NavidromeUri.isStream(uri) -> "stream.view"
+            else -> return null
+        }
+
+        val payload = NavidromeSecurity.generateAuthPayload(user, pass)
+        val normalizedBase = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+
+        val builder = "${normalizedBase}rest/$endpoint".toUri()
+            .buildUpon()
+            .appendQueryParameter("id", id)
+            .appendQueryParameter("u", payload.u)
+            .appendQueryParameter("t", payload.t)
+            .appendQueryParameter("s", payload.s)
+            .appendQueryParameter("v", payload.v)
+            .appendQueryParameter("c", payload.c)
+
+        if (NavidromeUri.isArt(uri)) {
+            builder.appendQueryParameter("size", DEFAULT_ART_SIZE.toString())
+        }
+
+        // Deliberately no `format` or `maxBitRate`: Navidrome then streams the original file,
+        // preserving the bit-perfect path for FLAC/ALAC sources.
+        return builder.build()
+    }
+
+    private companion object {
+        const val DEFAULT_ART_SIZE = 500
+    }
+}
+

--- a/app/src/main/java/com/example/tigerplayer/data/repository/AudioRepository.kt
+++ b/app/src/main/java/com/example/tigerplayer/data/repository/AudioRepository.kt
@@ -10,14 +10,12 @@ import com.example.tigerplayer.data.local.entity.CachedTrackEntity
 import com.example.tigerplayer.data.local.entity.PlaylistEntity
 import com.example.tigerplayer.data.model.AudioTrack
 import com.example.tigerplayer.data.model.Playlist
-import com.example.tigerplayer.data.remote.api.RemoteTrack
 import com.example.tigerplayer.data.source.LocalAudioDataSource
-import com.example.tigerplayer.utils.NavidromeSecurity
+import com.example.tigerplayer.utils.NavidromeMapper.toAudioTrack
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -53,13 +51,12 @@ class AudioRepository @Inject constructor(
                     val remoteResult = navidromeRepository.getAllRemoteTracks(user, pass)
 
                     remoteResult.onSuccess { remoteTracks ->
-                        // 🔥 PERFORMANCE FIX: Generate salt/token ONCE per sync, not per track
-                        val salt = UUID.randomUUID().toString().substring(0, 8)
-                        val token = NavidromeSecurity.generateToken(pass, salt)
-                        val authQuery = "u=$user&t=$token&s=$salt&v=1.16.1&c=TigerPlayer"
-
-                        remoteCache = remoteTracks.map { it.toAudioTrack(baseUrl, authQuery,pass) }
+                        // Tracks carry opaque `navidrome://` URIs; auth is applied at request time
+                        // by NavidromeUrlSigner, so nothing credential-bearing is ever persisted
+                        // (issue #44).
+                        remoteCache = remoteTracks.map { it.toAudioTrack() }
                     }.onFailure { error ->
+                        // Never log the URL or credentials - only the failure reason.
                         Log.e("AudioRepository", "Archive sync failed: ${error.message}")
                     }
                 }
@@ -72,33 +69,6 @@ class AudioRepository @Inject constructor(
         (local + remote).sortedBy { it.title.lowercase() }
     }
 
-    /**
-     * THE NAVIDROME RITUAL
-     * Optimized for high-quality streaming.
-     */
-    private fun RemoteTrack.toAudioTrack(baseUrl: String, u: String, p: String): AudioTrack {
-        val salt = UUID.randomUUID().toString().substring(0, 8)
-        val token = NavidromeSecurity.generateToken(p, salt)
-        val authQuery = "u=$u&t=$token&s=$salt&v=1.16.1&c=TigerPlayer"
-
-        // Bit-Perfect Consideration: Navidrome stream.view returns the original file unless transcoding is forced.
-        // We omit 'maxBitRate' and 'format' parameters to ensure we get the source file (FLAC/ALAC/High-VBR MP3).
-        return AudioTrack(
-            id = id,
-            title = title,
-            artist = artist,
-            album = album,
-            durationMs = duration.toLong() * 1000,
-            artworkUri = Uri.parse("${baseUrl}rest/getCoverArt.view?id=$id&$authQuery"),
-            uri = Uri.parse("${baseUrl}rest/stream.view?id=$id&$authQuery"),
-            trackNumber = track,
-            mimeType = "audio/$suffix",
-            bitrate = bitRate * 1000,
-            isRemote = true,
-            serverPath = id,
-            year = year?.toString()
-        )
-    }
 
     /**
      * LOCAL CACHE LOGIC

--- a/app/src/main/java/com/example/tigerplayer/engine/NetworkEngine.kt
+++ b/app/src/main/java/com/example/tigerplayer/engine/NetworkEngine.kt
@@ -47,17 +47,17 @@ class NetworkEngine @Inject constructor(
      * Fetches all remote tracks from Navidrome and maps them to AudioTracks.
      */
     suspend fun syncNavidromeArchives() {
-        val url = navidromePrefs.serverUrl.firstOrNull()
         val user = navidromePrefs.username.firstOrNull()
         val pass = navidromePrefs.password.firstOrNull()
 
-        if (url.isNullOrBlank() || user.isNullOrBlank() || pass.isNullOrBlank()) {
+        if (user.isNullOrBlank() || pass.isNullOrBlank()) {
             _remoteTracks.value = emptyList()
             return
         }
 
         navidromeRepository.getAllRemoteTracks(user, pass).onSuccess { remoteList ->
-            _remoteTracks.value = remoteList.map { it.toAudioTrack(url, user, pass) }
+            // Mapping carries no credentials; URIs are signed at request time (issue #44).
+            _remoteTracks.value = remoteList.map { it.toAudioTrack() }
         }.onFailure { error ->
             Log.e("NetworkEngine", "Failed to sync Navidrome: ${error.message}")
         }

--- a/app/src/main/java/com/example/tigerplayer/engine/StatsEngine.kt
+++ b/app/src/main/java/com/example/tigerplayer/engine/StatsEngine.kt
@@ -216,7 +216,10 @@ class StatsEngine @Inject constructor(
 
     private fun resolveSource(track: AudioTrack): MediaSource = when {
         track.id.startsWith("spotify:", ignoreCase = true) -> MediaSource.SPOTIFY
-        track.id.startsWith("navidrome:", ignoreCase = true) -> MediaSource.NAVIDROME
+        // Both separators are accepted: rows written before issue #44 may carry either, and a play
+        // attributed to the wrong source silently corrupts the per-source stats breakdown.
+        track.id.startsWith("navidrome_", ignoreCase = true) ||
+            track.id.startsWith("navidrome:", ignoreCase = true) -> MediaSource.NAVIDROME
         else -> MediaSource.LOCAL
     }
 

--- a/app/src/main/java/com/example/tigerplayer/service/AudioPlayerService.kt
+++ b/app/src/main/java/com/example/tigerplayer/service/AudioPlayerService.kt
@@ -21,6 +21,10 @@ import androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -30,6 +34,8 @@ import com.example.tigerplayer.BuildConfig
 import com.example.tigerplayer.data.local.AudioReactiveHapticsProfile
 import com.example.tigerplayer.data.local.PlaybackPrefs
 import com.example.tigerplayer.data.local.SettingsDataStore
+import com.example.tigerplayer.data.remote.NavidromeUri
+import com.example.tigerplayer.data.remote.NavidromeUrlSigner
 import com.example.tigerplayer.MainActivity
 import com.example.tigerplayer.R
 import com.example.tigerplayer.engine.AcousticNode
@@ -39,6 +45,7 @@ import com.example.tigerplayer.engine.FilterType
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -69,6 +76,7 @@ class AudioPlayerService : MediaSessionService() {
     @Inject lateinit var playbackPrefs: PlaybackPrefs
     @Inject lateinit var settingsDataStore: SettingsDataStore
     @Inject lateinit var hapticsDebugMonitor: HapticsDebugMonitor
+    @Inject lateinit var navidromeUrlSigner: NavidromeUrlSigner
 
     private var isBitPerfectMode = false // Initial state to ensure first call triggers
     private var routeToSystemDecoderDsp = false
@@ -161,12 +169,16 @@ class AudioPlayerService : MediaSessionService() {
         val audioAttributes = AudioAttributes.Builder()
             .setUsage(C.USAGE_MEDIA)
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-            // AUDIOPHILE COMPATIBILITY: Explicitly flag as high-priority music 
+            // AUDIOPHILE COMPATIBILITY: Explicitly flag as high-priority music
             // to improve Samsung's "Separate App Sound" routing accuracy.
             .setAllowedCapturePolicy(C.ALLOW_CAPTURE_BY_NONE)
             .build()
 
         player = ExoPlayer.Builder(this, renderersFactory)
+            .setMediaSourceFactory(
+                DefaultMediaSourceFactory(this)
+                    .setDataSourceFactory(buildNavidromeAwareDataSourceFactory())
+            )
             .setAudioAttributes(audioAttributes, true)
             .setHandleAudioBecomingNoisy(true)
             .setWakeMode(C.WAKE_MODE_LOCAL)
@@ -260,6 +272,34 @@ class AudioPlayerService : MediaSessionService() {
         invalidateCustomLayout()
     }
 
+    /**
+     * Data-source chain that resolves opaque `navidrome://` URIs into freshly signed URLs at open
+     * time (issue #44).
+     *
+     * Signing here rather than at mapping time is what makes a restored queue playable: Subsonic
+     * salted tokens rotate, so a URL persisted in the queue snapshot would be dead on replay.
+     * The resolver runs on the loading thread and only reads in-memory credentials, so it does no
+     * disk I/O.
+     */
+    @OptIn(UnstableApi::class)
+    private fun buildNavidromeAwareDataSourceFactory(): DataSource.Factory {
+        val upstream = DefaultDataSource.Factory(this)
+
+        return ResolvingDataSource.Factory(upstream) { dataSpec ->
+            if (!NavidromeUri.isNavidrome(dataSpec.uri)) {
+                dataSpec
+            } else {
+                val signed = navidromeUrlSigner.sign(dataSpec.uri)
+                if (signed == null) {
+                    // No credentials: fail loudly rather than issuing an unsigned request that the
+                    // server would reject with a confusing error. Never log the URI itself.
+                    throw IOException("Navidrome credentials unavailable; cannot resolve stream")
+                }
+                dataSpec.withUri(signed)
+            }
+        }
+    }
+
     @OptIn(UnstableApi::class)
     private fun setAudioOffloadEnabled(enabled: Boolean) {
         // AUDIOPHILE COMPATIBILITY: On Samsung, we ONLY allow Offload in Bit-Perfect mode.
@@ -314,7 +354,7 @@ class AudioPlayerService : MediaSessionService() {
 
             player.seekTo(currentPosition)
             player.prepare()
-            
+
             if (wasPlaying) {
                 player.play()
                 // Ramp back up smoothly

--- a/app/src/main/java/com/example/tigerplayer/utils/NavidromeSecurity.kt
+++ b/app/src/main/java/com/example/tigerplayer/utils/NavidromeSecurity.kt
@@ -2,10 +2,9 @@ package com.example.tigerplayer.utils
 
 import java.security.MessageDigest
 import java.util.UUID
-import androidx.core.net.toUri
 import com.example.tigerplayer.data.model.AudioTrack
+import com.example.tigerplayer.data.remote.NavidromeUri
 import com.example.tigerplayer.data.remote.api.RemoteTrack
-import com.example.tigerplayer.utils.NavidromeSecurity
 
 data class NavidromeAuth(
     val u: String,
@@ -23,7 +22,6 @@ object NavidromeSecurity {
         return NavidromeAuth(u = username, t = token, s = salt)
     }
 
-    // This helper is used by AudioRepository to generate valid Stream URIs
     fun generateToken(pass: String, salt: String): String {
         return md5(pass + salt)
     }
@@ -33,96 +31,47 @@ object NavidromeSecurity {
         return md.digest(input.toByteArray()).joinToString("") { "%02x".format(it) }
     }
 }
-object NavidromeArtHelper {
-    /**
-     * Forges the authenticated URL required by Coil to fetch the image.
-     */
-    fun getCoverArtUrl(
-        serverUrl: String, // From your DataStore/HostManager
-        username: String,
-        pass: String,
-        coverArtId: String,
-        size: Int = 500 // Subsonic can scale images on the server!
-    ): String {
-        val payload = NavidromeSecurity.generateAuthPayload(username, pass)
-
-        // Ensure the server URL ends with a slash to prevent malformed URLs
-        val baseUrl = if (serverUrl.endsWith("/")) serverUrl else "$serverUrl/"
-
-        return "${baseUrl}rest/getCoverArt.view?" +
-                "id=$coverArtId" +
-                "&u=${payload.u}" +
-                "&t=${payload.t}" +
-                "&s=${payload.s}" +
-                "&v=${payload.v}" +
-                "&c=${payload.c}" +
-                "&size=$size"
-    }
-}
 
 object NavidromeMapper {
 
     /**
-     * The Great Convergence: Transmutes a RemoteTrack from the server
-     * into a standard AudioTrack that your UI and Player already understand.
+     * Transmutes a [RemoteTrack] from the server into a standard [AudioTrack].
+     *
+     * URIs are deliberately **opaque** (`navidrome://stream/<id>`, `navidrome://art/<id>`): they
+     * carry no credentials, so they are safe to persist in the queue snapshot and replay after a
+     * restart. Signing happens at request time - see `NavidromeUrlSigner` (issue #44).
+     *
+     * This is the single mapper for Navidrome tracks. A second, divergent one previously lived in
+     * `AudioRepository` and emitted malformed URLs with a duplicated `u=` parameter.
      */
-    fun RemoteTrack.toAudioTrack(
-        serverUrl: String,
-        username: String,
-        pass: String
-    ): AudioTrack {
-        // Generate the auth tokens needed for the URLs
-        val payload = NavidromeSecurity.generateAuthPayload(username, pass)
-        val baseUrl = if (serverUrl.endsWith("/")) serverUrl else "$serverUrl/"
-
-        // 1. FORGE THE AUDIO STREAM URI
-        // This is the direct link ExoPlayer/Media3 will use to stream the song
-        val streamUrl = "${baseUrl}rest/stream.view?" +
-                "id=${this.id}" +
-                "&u=${payload.u}" +
-                "&t=${payload.t}" +
-                "&s=${payload.s}" +
-                "&v=${payload.v}" +
-                "&c=${payload.c}"
-
-        // 2. FORGE THE COVER ART URI
-        // Coil will handle caching this so it doesn't drain data on every scroll
-        val artUrl = "${baseUrl}rest/getCoverArt.view?" +
-                "id=${this.coverArtId ?: this.albumId ?: this.id}" + // Fallbacks just in case
-                "&u=${payload.u}" +
-                "&t=${payload.t}" +
-                "&s=${payload.s}" +
-                "&v=${payload.v}" +
-                "&c=${payload.c}" +
-                "&size=500"
+    fun RemoteTrack.toAudioTrack(): AudioTrack {
+        val artId = this.coverArtId ?: this.albumId ?: this.id
 
         return AudioTrack(
-            // Prefix the ID so it never collides with a local MediaStore ID
-            id = "navidrome_${this.id}",
+            // Prefixed so it never collides with a local MediaStore id, and so MediaSource
+            // resolution can identify remote plays.
+            id = "${NavidromeUri.TRACK_ID_PREFIX}${this.id}",
             title = this.title,
             artist = this.artist,
             album = this.album,
-            uri = streamUrl.toUri(),
-            artworkUri = artUrl.toUri(),
+            uri = NavidromeUri.stream(this.id),
+            artworkUri = NavidromeUri.art(artId),
 
-            // Subsonic returns duration in seconds, Android needs milliseconds!
+            // Subsonic returns duration in seconds, Android needs milliseconds.
             durationMs = (this.duration * 1000L),
 
-            mimeType = "audio/${this.suffix.lowercase()}", // e.g., "audio/mp3", "audio/flac"
+            mimeType = "audio/${this.suffix.lowercase()}",
             isLocal = false,
             isRemote = true,
             bitrate = this.bitRate,
-            sampleRate = 0, // Navidrome doesn't typically expose sample rate here
+            sampleRate = 0, // Navidrome does not expose sample rate on this endpoint.
             trackNumber = this.track,
-            serverPath = streamUrl,
+            serverPath = this.id,
             year = this.year?.toString(),
             isLiked = false,
 
-            // --- THE LYRICS LINK ---
-            // Since remote tracks don't have a local file path (like /storage/emulated/0/...),
-            // we feed the stream URL or a unique Navidrome string to the path field.
-            // This ensures your LyricsRepository doesn't crash and has a unique key to hash.
-            path = "navidrome://${this.id}"
+            // Remote tracks have no on-disk path; a stable opaque key keeps LyricsRepository happy.
+            path = NavidromeUri.stream(this.id).toString()
         )
     }
 }

--- a/app/src/test/java/com/example/tigerplayer/data/remote/NavidromeUriTest.kt
+++ b/app/src/test/java/com/example/tigerplayer/data/remote/NavidromeUriTest.kt
@@ -1,0 +1,153 @@
+package com.example.tigerplayer.data.remote
+
+import android.net.Uri
+import com.example.tigerplayer.data.local.NavidromePrefs
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Coverage for issue #44.
+ *
+ * Persisted Navidrome URIs must carry no credentials, and signing must happen per request so a
+ * restored queue still plays after the original salted token has rotated.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NavidromeUriTest {
+
+    private val prefs = mockk<NavidromePrefs>(relaxed = true)
+
+    private fun signer(
+        base: String? = "https://music.example.com/",
+        user: String? = "tyej",
+        pass: String? = "hunter2"
+    ): NavidromeUrlSigner {
+        every { prefs.serverUrlSnapshot() } returns base
+        every { prefs.usernameSnapshot() } returns user
+        every { prefs.passwordSnapshot() } returns pass
+        return NavidromeUrlSigner(prefs)
+    }
+
+    // --- opaque URIs ---
+
+    @Test
+    fun `a stream uri carries the id and nothing else`() {
+        val uri = NavidromeUri.stream("track-123")
+
+        assertEquals("navidrome://stream/track-123", uri.toString())
+        assertEquals("track-123", NavidromeUri.resourceId(uri))
+        assertTrue(NavidromeUri.isStream(uri))
+        assertFalse(NavidromeUri.isArt(uri))
+    }
+
+    @Test
+    fun `an art uri is distinguishable from a stream uri`() {
+        val uri = NavidromeUri.art("album-9")
+
+        assertEquals("navidrome://art/album-9", uri.toString())
+        assertTrue(NavidromeUri.isArt(uri))
+        assertFalse(NavidromeUri.isStream(uri))
+    }
+
+    @Test
+    fun `an opaque uri never contains credential parameters`() {
+        val stream = NavidromeUri.stream("abc").toString()
+        val art = NavidromeUri.art("abc").toString()
+
+        listOf(stream, art).forEach { value ->
+            assertFalse("uri must not carry a username: $value", value.contains("u="))
+            assertFalse("uri must not carry a token: $value", value.contains("t="))
+            assertFalse("uri must not carry a salt: $value", value.contains("s="))
+        }
+    }
+
+    @Test
+    fun `a non navidrome uri is not claimed`() {
+        val http = Uri.parse("https://example.com/song.flac")
+
+        assertFalse(NavidromeUri.isNavidrome(http))
+        assertNull(NavidromeUri.resourceId(http))
+    }
+
+    // --- signing ---
+
+    @Test
+    fun `signing a stream uri produces exactly one of each auth parameter`() {
+        val signed = signer().sign(NavidromeUri.stream("track-123"))!!
+
+        assertEquals("track-123", signed.getQueryParameter("id"))
+        assertEquals("tyej", signed.getQueryParameter("u"))
+        assertEquals(1, signed.getQueryParameters("u").size)
+        assertEquals(1, signed.getQueryParameters("t").size)
+        assertEquals(1, signed.getQueryParameters("s").size)
+        assertTrue(signed.toString().startsWith("https://music.example.com/rest/stream.view?"))
+    }
+
+    @Test
+    fun `signing an art uri targets the cover art endpoint and requests a size`() {
+        val signed = signer().sign(NavidromeUri.art("album-9"))!!
+
+        assertTrue(signed.toString().contains("rest/getCoverArt.view"))
+        assertEquals("500", signed.getQueryParameter("size"))
+    }
+
+    @Test
+    fun `a stream url omits format and bitrate so the original file is served`() {
+        val signed = signer().sign(NavidromeUri.stream("track-123"))!!
+
+        assertNull(signed.getQueryParameter("format"))
+        assertNull(signed.getQueryParameter("maxBitRate"))
+    }
+
+    @Test
+    fun `a base url without a trailing slash is normalized`() {
+        val signed = signer(base = "https://music.example.com").sign(NavidromeUri.stream("x"))!!
+
+        assertTrue(signed.toString().startsWith("https://music.example.com/rest/stream.view?"))
+        assertFalse(signed.toString().contains("com//rest"))
+    }
+
+    @Test
+    fun `each signature uses a fresh salt and token`() {
+        val s = signer()
+        val first = s.sign(NavidromeUri.stream("track-123"))!!
+        val second = s.sign(NavidromeUri.stream("track-123"))!!
+
+        assertTrue(
+            "salt must rotate per request",
+            first.getQueryParameter("s") != second.getQueryParameter("s")
+        )
+        assertTrue(
+            "token must rotate with the salt",
+            first.getQueryParameter("t") != second.getQueryParameter("t")
+        )
+    }
+
+    @Test
+    fun `signing returns null when credentials are absent`() {
+        assertNull(signer(base = null).sign(NavidromeUri.stream("x")))
+        assertNull(signer(user = null).sign(NavidromeUri.stream("x")))
+        assertNull(signer(pass = null).sign(NavidromeUri.stream("x")))
+        assertNull(signer(user = "").sign(NavidromeUri.stream("x")))
+    }
+
+    @Test
+    fun `signing ignores uris that are not ours`() {
+        assertNull(signer().sign(Uri.parse("https://example.com/song.flac")))
+        assertNull(signer().sign(Uri.parse("content://media/external/audio/media/12")))
+    }
+
+    @Test
+    fun `an unknown navidrome host is rejected rather than guessed`() {
+        val odd = Uri.parse("navidrome://unknown/track-1")
+
+        assertNull(signer().sign(odd))
+    }
+}
+

--- a/app/src/test/java/com/example/tigerplayer/engine/StatsEnginePlayTrackingTest.kt
+++ b/app/src/test/java/com/example/tigerplayer/engine/StatsEnginePlayTrackingTest.kt
@@ -232,6 +232,32 @@ class StatsEnginePlayTrackingTest {
         assertTrue(source.captured == MediaSource.SPOTIFY)
     }
 
+    @Test
+    fun `both navidrome id separators resolve to the navidrome source`() = runTest {
+        // Ids written before issue #44 may carry either separator. Misattributing a play would
+        // silently corrupt the per-source stats breakdown.
+        listOf("navidrome_abc", "navidrome:abc").forEach { id ->
+            val repository = mockk<HistoryRepository>(relaxed = true)
+            val localClock = FakeElapsedTimeSource()
+            val localEngine = StatsEngine(repository, localClock)
+            val source = slot<MediaSource>()
+            localEngine.onTrackChanged(track(id = id, durationMs = FIVE_MINUTES), isPlaying = true)
+            localClock.advance(THREE_MINUTES)
+            localEngine.flushPendingPlay()
+            coVerify(exactly = 1) {
+                repository.addTrackToHistory(
+                    trackId = id,
+                    title = any(),
+                    artist = any(),
+                    album = any(),
+                    imageUrl = any(),
+                    durationListenedMs = any(),
+                    source = capture(source)
+                )
+            }
+            assertEquals(MediaSource.NAVIDROME, source.captured)
+        }
+    }
     private companion object {
         const val FIVE_MINUTES = 5 * 60 * 1000L
         const val THREE_MINUTES = 3 * 60 * 1000L

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ youtubePlayer = "13.0.0"
 # Testing
 junit = "4.13.2"
 junitVersion = "1.3.0"
+robolectric = "4.16.1"
 espressoCore = "3.7.0"
 animation = "1.11.4"
 roomVersion = "2.8.4"
@@ -111,6 +112,7 @@ play-services-auth = { group = "com.google.android.gms", name = "play-services-a
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-animation = { group = "androidx.compose.animation", name = "animation", version.ref = "animation" }


### PR DESCRIPTION
### Summary of Changes

Closes #44.

Navidrome stream and artwork URLs were built with the Subsonic salted token baked in, then persisted — into Room, into the queue snapshot, into every `MediaItem`. Those tokens rotate, so a restored queue replayed URLs that were valid when written and dead on replay. Credentials were also written to disk in plaintext as part of the URL.

`AudioRepository` additionally carried a **second, divergent mapper** that interpolated the caller's pre-built `authQuery` into the `u=` slot, emitting URLs of the form `?id=x&u=u=<user>&t=..&s=..&v=..&c=..&t=..&s=..`. That path was malformed for every remote track.

**Now:** tracks carry opaque `navidrome://stream/<id>` and `navidrome://art/<id>` URIs that contain no credentials and are safe to persist indefinitely. Signing happens at request time:

| Path | Mechanism |
|---|---|
| Playback | `ResolvingDataSource.Factory` in `AudioPlayerService` |
| Artwork | Coil `Interceptor` installed via `ImageLoaderFactory` |

Both read in-memory credentials only, so neither does disk I/O on a loading thread. Missing credentials fail loudly on the playback path rather than issuing an unsigned request; artwork falls through to the caller's error placeholder.

### Notable decisions

- **Coil cache keys are pinned to the opaque URI.** Each `sign()` mints a fresh salt, so the signed URL differs every call — deriving keys from it would make every lookup a miss and re-download artwork on every scroll.
- **The `navidrome_` track id prefix is preserved.** Track ids are foreign keys in `playlist_track_cross_ref`, `playback_history`, `lyrics_cache` and `waveform_cache`, and are field 0 of the positional queue snapshot. Changing the separator to `navidrome:` would have orphaned every one of those rows with no migration available to repair them (#43 is not yet done).
- **`resolveSource` accepts both separators.** Ids written before this change may carry either; misattribution would silently corrupt the per-source stats breakdown.
- **No `format` or `maxBitRate` parameters**, so Navidrome serves the original file and the bit-perfect path is preserved for FLAC/ALAC.

### Verification

| Gate | Result |
|---|---|
| `testDebugUnitTest` | **56 tests, 0 failures** (was 43) |
| `lintDebug` | **89 issues, 0 errors** (baseline 91 — dead code removal) |
| `assembleDebug` | BUILD SUCCESSFUL |

13 new tests: 12 in `NavidromeUriTest` covering URI construction, round-trip, resource-id extraction, stream/art discrimination, unknown hosts and absent credentials; 1 in `StatsEnginePlayTrackingTest` pinning both id separators to `MediaSource.NAVIDROME`.

Robolectric was added **test-only** so `android.net.Uri` resolves on the JVM. Declared in the version catalog, no new `force(...)`.

### Device verification needed

This is a remote-playback change and CI cannot exercise it. Please confirm against a real Navidrome server:

- [ ] Remote track plays from the library
- [ ] Cover art loads, and does **not** re-download on repeated scroll
- [ ] Queue survives a full app restart and still plays (the core regression)
- [ ] Playback still works after leaving the app idle long enough for the original token to rotate
- [ ] Existing playlists containing Navidrome tracks still resolve

### Known limitation

Any Navidrome track ids persisted by the old `AudioRepository` mapper were stored **bare**, with no prefix at all. Those references are not recoverable without a migration and will need re-adding. Ids written via `NavidromeMapper` (the `navidrome_` form) are unaffected.